### PR TITLE
Multiple bank accounts, holdings, and FinTS state cache

### DIFF
--- a/influxdb_banktool/cache.py
+++ b/influxdb_banktool/cache.py
@@ -1,0 +1,37 @@
+from hashlib import sha256
+from base64 import b64encode, b64decode
+import json
+import os
+
+CACHE_PATH = os.path.expanduser('~/.influxdb-banktool/accounts_cache.json')
+
+# Read details for item from cache.
+# A hashed representation of item is used as cache key.
+def cache_read(item):
+    key = sha256(json.dumps(item, sort_keys=True).encode()).hexdigest()
+
+    try:
+        with open(CACHE_PATH, "r") as f:
+            cache = json.load(f)
+
+        b64data = cache[key]
+        return b64decode(b64data)
+    except:
+        return None
+
+# Write bytes-like data to cache, in base64 encoding.
+# A hashed representation of item is used as cache key.
+def cache_write(item, data):
+    key = sha256(json.dumps(item, sort_keys=True).encode()).hexdigest()
+
+    try:
+        with open(CACHE_PATH, "r") as f:
+            cache = json.load(f)
+    except:
+        cache = {}
+
+    b64data = b64encode(data)
+    cache[key] = b64data.decode()
+
+    with open(CACHE_PATH, "w") as f:
+       json.dump(cache, f)

--- a/influxdb_banktool/main.py
+++ b/influxdb_banktool/main.py
@@ -8,11 +8,61 @@ from influxdb import InfluxDBClient
 
 from influxdb_banktool.settings import config
 from influxdb_banktool.utils import parse_influxdb_timestamp
-
+from influxdb_banktool.cache import cache_read, cache_write
 
 def main():
     client = InfluxDBClient(*config['influxdb_config'])
-    query = 'SELECT LAST(int_value) FROM balance'
+
+    # Original config was just a single dictionary, supporting a single bank
+    # account. This allows to have a list of those dicts instead and check more
+    # than one bank account
+    if config['fints_config'] is dict:
+        bank_configs = [ config['fints_config'] ]
+    else:
+        bank_configs = config['fints_config']
+
+    for bank_config in bank_configs:
+        f = init_fints(bank_config)
+        accounts = f.get_sepa_accounts()
+        for account in accounts:
+            since = calculate_account_timeframe(client, account.iban)
+
+            transactions = get_transactions(f, account, start=since)
+            if len(transactions) > 0:
+                balances = get_balance_by_date(transactions)
+            else:
+                b = f.get_balance(account)
+                balances = {
+                    b.date: b.amount.amount
+                }
+            write_balances_to_influxdb(account.iban, client, balances)
+
+            holdings = f.get_holdings(account)
+            write_holdings_to_influxdb(account.iban, client, holdings)
+
+        deconstruct_fints(bank_config, f)
+
+def init_fints(account_config):
+    data = cache_read(account_config)
+    fints = FinTS3PinTanClient(**account_config, from_data = data)
+    minimal_interactive_cli_bootstrap(fints)
+    # Since PSD2, a TAN might be needed for dialog initialization. Let's check if there is one required
+    if fints.init_tan_response:
+        print("A TAN is required", fints.init_tan_response.challenge)
+        tan = input('Please enter TAN:')
+        fints.send_tan(fints.init_tan_response, tan)
+
+    return fints
+
+def deconstruct_fints(account_config, fints):
+    data = fints.deconstruct(including_private=True)
+    cache_write(account_config, data)
+
+def get_accounts(fints):
+    accounts = fints.get_sepa_accounts()
+
+def calculate_account_timeframe(client, account_id):
+    query = f"SELECT LAST(int_value) FROM balance WHERE account='{account_id}'"
 
     try:
         rs = next(client.query(query).get_points())
@@ -20,24 +70,10 @@ def main():
     except (StopIteration, KeyError):
         since = date.today() - timedelta(days=30)
 
-    transactions = get_transactions(start=since)
-    balances = get_balance_by_date(transactions)
-    write_balances_to_influxdb(client, balances)
+    return since
 
-
-def get_transactions(start, end=date.today()):
-    fints = FinTS3PinTanClient(**config['fints_config'])
-    minimal_interactive_cli_bootstrap(fints)
-    with fints:
-        # Since PSD2, a TAN might be needed for dialog initialization. Let's check if there is one required
-        if fints.init_tan_response:
-            print("A TAN is required", fints.init_tan_response.challenge)
-            tan = input('Please enter TAN:')
-            fints.send_tan(fints.init_tan_response, tan)
-
-        accounts = fints.get_sepa_accounts()
-
-        statement = fints.get_transactions(accounts[0], start, end)
+def get_transactions(fints, account, start, end=date.today()):
+    statement = fints.get_transactions(account, start, end)
 
     return statement
 
@@ -55,13 +91,13 @@ def get_balance_by_date(data):
     return balance_by_date
 
 
-def write_balances_to_influxdb(client, data):
+def write_balances_to_influxdb(account_id, client, data):
     for key, value in data.items():
         json_body = [
             {
                 "measurement": "balance",
                 "tags": {
-                    "account": "default"
+                    "account": account_id
                 },
                 "time": datetime(key.year, key.month, key.day),
                 "fields": {
@@ -73,6 +109,29 @@ def write_balances_to_influxdb(client, data):
 
         client.write_points(json_body)
 
+def write_holdings_to_influxdb(account_id, client, data):
+    for holding in data:
+        json_body = [
+            {
+                "measurement": "holdings",
+                "tags": {
+                    "account": account_id,
+                    "ISIN": holding.ISIN,
+                    "name": holding.name,
+                    "currency": holding.value_symbol
+                },
+                "time": datetime(holding.valuation_date.year,
+                            holding.valuation_date.month,
+                            holding.valuation_date.day),
+                "fields": {
+                    "total_value": float(holding.total_value),
+                    "pieces": float(holding.pieces),
+                    "market_value": float(holding.market_value)
+                }
+            }
+        ]
+
+        client.write_points(json_body)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Sorry, this is a big one, I hope that's fine.

# Multiple bank accounts
This can have two meanings, not sure what the right wording here is. But this change allows both, multiple bank account configurations in the accounts.json file, by using a list of dicts instead of a single dict. Old format is supported for backwards compatibility.

And it also supports multiple SEPA accounts within one of these bank accounts. Instead of using "default" as account key in Influx, it uses the IBAN as account identifier.

# Holdings
In addition to the regular account balances, holdings for an account are also requested and entered into InfluxDB, in the "holdings" table.

# FinTS state cache
In addition to the accounts.json file, I created a second file in that folder, accounts_cache.json. When the FinTS client is created, the script checks whether there is matching data object from an older FinTS session in that cache file. If so, that is used to initialize the FinTS client. When done with all requests, the FinTS object is properly deconstructed and its data stored in the cache for the next run.

This allows to not have to enter the TAN method again after running it once. This was a problem when I tried this with Deutsche Bank, it would always request the TAN method to use, even if we didn't need a TAN for the request.

# Tested banks
Tested this with Deutsche Bank and comdirect.